### PR TITLE
Breaking: request.body() returns an object

### DIFF
--- a/applyGraphQL.ts
+++ b/applyGraphQL.ts
@@ -41,7 +41,7 @@ export const applyGraphQL = async ({
     if (request.hasBody) {
       try {
         const contextResult = context ? await context(ctx) : undefined;
-        const body = (await request.body()).value;
+        const body = await request.body().value;
         const result = await (graphql as any)(
           schema,
           body.query,


### PR DESCRIPTION
In v6.0.0 version of Oak request.body() returns an object where the key value is a promise. https://github.com/oakserver/oak/commit/bd03d60b8d7c32bbe1f433afbaccd475000beea9

Causes the following error response with all queries:

```
{
  "errors": [
    {}
  ]
}
```