### PR TITLE
Update for deno 1.2.0 - std: 0.61

### DIFF
--- a/egg.yaml
+++ b/egg.yaml
@@ -1,7 +1,7 @@
 name: oak-graphql
 description: A simple graphql middleware for oak deno framework.
 stable: false
-version: 0.5.7
+version: 0.5.8
 entry: ./mod.ts
 repository: https://github.com/aaronwlee/Oak-GraphQL
 files:
@@ -9,6 +9,7 @@ files:
   - deps.ts
   - applyGraphQL.ts
   - mod.ts
+  - graphql-tag/**/*
   - graphql-playground-html/**/*
   - graphql-tools/**/*
   - graphql-subscriptions/**/*


### PR DESCRIPTION
In this PR oak server import goes to 6.0.1, which uses deno std 0.61, which is used by deno 1.2.x