### PR TITLE
small fixes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ app.use(async (ctx, next) => {
   ctx.response.headers.set("X-Response-Time", `${ms}ms`);
 });
 
-const types = (gql as any)`
+const types = gql`
 type User {
   firstName: String
   lastName: String

--- a/egg.yaml
+++ b/egg.yaml
@@ -1,7 +1,7 @@
 name: oak-graphql
 description: A simple graphql middleware for oak deno framework.
 stable: false
-version: 0.5.7
+version: 0.5.8
 entry: ./mod.ts
 repository: https://github.com/aaronwlee/Oak-GraphQL
 files:
@@ -9,6 +9,7 @@ files:
   - deps.ts
   - applyGraphQL.ts
   - mod.ts
+  - graphql-tag/**/*
   - graphql-playground-html/**/*
   - graphql-tools/**/*
   - graphql-subscriptions/**/*

--- a/graphql-subscriptions/pubsub.ts
+++ b/graphql-subscriptions/pubsub.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "https://deno.land/std@0.63.0/node/events.ts";
+import { EventEmitter } from "https://deno.land/std@0.61.0/node/events.ts";
 import { PubSubEngine } from "./pubsub-engine.ts";
 
 export interface PubSubOptions {

--- a/graphql-subscriptions/pubsub.ts
+++ b/graphql-subscriptions/pubsub.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'https://deno.land/std/node/events.ts';
-import { PubSubEngine } from './pubsub-engine.ts';
+import { EventEmitter } from "https://deno.land/std@0.63.0/node/events.ts";
+import { PubSubEngine } from "./pubsub-engine.ts";
 
 export interface PubSubOptions {
   eventEmitter?: EventEmitter;
@@ -22,7 +22,10 @@ export class PubSub extends PubSubEngine {
     return Promise.resolve();
   }
 
-  public subscribe(triggerName: string, onMessage: (...args: any[]) => void): Promise<number> {
+  public subscribe(
+    triggerName: string,
+    onMessage: (...args: any[]) => void
+  ): Promise<number> {
     this.ee.addListener(triggerName, onMessage);
     this.subIdCounter = this.subIdCounter + 1;
     this.subscriptions[this.subIdCounter] = [triggerName, onMessage];


### PR DESCRIPTION
- Fix std version to 0.61 to be compliant with last oak version. Current std version is 0.66. It should be checked once oak is upgraded.
- Remove `gql as any` from Readme.md, as now it is exported as any and thus is not required any more to use it like that (allowing some editors as vscode to format gql