### PR TITLE
Updated imports and exports of types to work with typescript 4

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,8 +12,8 @@ A simple graphql middleware for oak deno framework.
 
 ## Simple example
 ```ts
-// deno 1.2.x required oak version up to v6.0.1
-import { Application, Router, RouterContext } from "https://deno.land/x/oak@v6.0.1/mod.ts";
+
+import { Application, Router, RouterContext } from "https://deno.land/x/oak@v6.2.0/mod.ts";
 import { applyGraphQL, gql, GQLError } from "https://deno.land/x/oak_graphql/mod.ts";
 
 const app = new Application();

--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ app.use(async (ctx, next) => {
   ctx.response.headers.set("X-Response-Time", `${ms}ms`);
 });
 
-const types = (gql as any)`
+const types = gql`
 type User {
   firstName: String
   lastName: String

--- a/egg.yaml
+++ b/egg.yaml
@@ -1,7 +1,7 @@
 name: oak-graphql
 description: A simple graphql middleware for oak deno framework.
 stable: false
-version: 0.5.7
+version: 0.5.8
 entry: ./mod.ts
 repository: https://github.com/aaronwlee/Oak-GraphQL
 files:
@@ -9,6 +9,7 @@ files:
   - deps.ts
   - applyGraphQL.ts
   - mod.ts
+  - graphql-tag/**/*
   - graphql-playground-html/**/*
   - graphql-tools/**/*
   - graphql-subscriptions/**/*

--- a/graphql-subscriptions/index.ts
+++ b/graphql-subscriptions/index.ts
@@ -1,4 +1,5 @@
 export { PubSubEngine } from "./pubsub-engine.ts";
 export { PubSub } from "./pubsub.ts";
 export type { PubSubOptions } from "./pubsub.ts";
-export { withFilter, ResolverFn, FilterFn } from "./with-filter.ts";
+export { withFilter } from "./with-filter.ts";
+export type { ResolverFn, FilterFn } from "./with-filter.ts";

--- a/graphql-subscriptions/index.ts
+++ b/graphql-subscriptions/index.ts
@@ -1,3 +1,4 @@
-export { PubSubEngine } from './pubsub-engine.ts';
-export { PubSub, PubSubOptions } from './pubsub.ts';
-export { withFilter, ResolverFn, FilterFn } from './with-filter.ts';
+export { PubSubEngine } from "./pubsub-engine.ts";
+export { PubSub } from "./pubsub.ts";
+export type { PubSubOptions } from "./pubsub.ts";
+export { withFilter, ResolverFn, FilterFn } from "./with-filter.ts";

--- a/graphql-subscriptions/pubsub.ts
+++ b/graphql-subscriptions/pubsub.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "https://deno.land/std@0.61.0/node/events.ts";
+import { EventEmitter } from "https://deno.land/std@0.69.0/node/events.ts";
 import { PubSubEngine } from "./pubsub-engine.ts";
 
 export interface PubSubOptions {

--- a/graphql-subscriptions/pubsub.ts
+++ b/graphql-subscriptions/pubsub.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "https://deno.land/std@0.63.0/node/events.ts";
+import { EventEmitter } from "https://deno.land/std@0.61.0/node/events.ts";
 import { PubSubEngine } from "./pubsub-engine.ts";
 
 export interface PubSubOptions {

--- a/graphql-subscriptions/pubsub.ts
+++ b/graphql-subscriptions/pubsub.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'https://deno.land/std/node/events.ts';
-import { PubSubEngine } from './pubsub-engine.ts';
+import { EventEmitter } from "https://deno.land/std@0.63.0/node/events.ts";
+import { PubSubEngine } from "./pubsub-engine.ts";
 
 export interface PubSubOptions {
   eventEmitter?: EventEmitter;
@@ -22,7 +22,10 @@ export class PubSub extends PubSubEngine {
     return Promise.resolve();
   }
 
-  public subscribe(triggerName: string, onMessage: (...args: any[]) => void): Promise<number> {
+  public subscribe(
+    triggerName: string,
+    onMessage: (...args: any[]) => void
+  ): Promise<number> {
     this.ee.addListener(triggerName, onMessage);
     this.subIdCounter = this.subIdCounter + 1;
     this.subscriptions[this.subIdCounter] = [triggerName, onMessage];

--- a/graphql-tools/schema/addErrorLoggingToSchema.ts
+++ b/graphql-tools/schema/addErrorLoggingToSchema.ts
@@ -1,18 +1,22 @@
-import { mapSchema, MapperKind } from '../utils/index.ts';
-import { decorateWithLogger } from './decorateWithLogger.ts';
-import { ILogger } from './types.ts';
+import { mapSchema, MapperKind } from "../utils/index.ts";
+import { decorateWithLogger } from "./decorateWithLogger.ts";
+import type { ILogger } from "./types.ts";
 
 export function addErrorLoggingToSchema(schema: any, logger?: ILogger): any {
   if (!logger) {
-    throw new Error('Must provide a logger');
+    throw new Error("Must provide a logger");
   }
-  if (typeof logger.log !== 'function') {
-    throw new Error('Logger.log must be a function');
+  if (typeof logger.log !== "function") {
+    throw new Error("Logger.log must be a function");
   }
   return mapSchema(schema, {
     [MapperKind.OBJECT_FIELD]: (fieldConfig: any, fieldName, typeName) => ({
       ...fieldConfig,
-      resolve: decorateWithLogger(fieldConfig.resolve, logger, `${typeName}.${fieldName}`),
+      resolve: decorateWithLogger(
+        fieldConfig.resolve,
+        logger,
+        `${typeName}.${fieldName}`
+      ),
     }),
   });
 }

--- a/graphql-tools/schema/buildSchemaFromTypeDefinitions.ts
+++ b/graphql-tools/schema/buildSchemaFromTypeDefinitions.ts
@@ -1,15 +1,26 @@
-import { parse, extendSchema, buildASTSchema, GraphQLSchema, } from "../../deps.ts";
+import {
+  parse,
+  extendSchema,
+  buildASTSchema,
+  GraphQLSchema,
+} from "../../deps.ts";
 
-import { ITypeDefinitions, GraphQLParseOptions } from '../utils/index.ts';
+import type { ITypeDefinitions, GraphQLParseOptions } from "../utils/index.ts";
 
-import { extractExtensionDefinitions, filterExtensionDefinitions } from './extensionDefinitions.ts';
-import { concatenateTypeDefs } from './concatenateTypeDefs.ts';
+import {
+  extractExtensionDefinitions,
+  filterExtensionDefinitions,
+} from "./extensionDefinitions.ts";
+import { concatenateTypeDefs } from "./concatenateTypeDefs.ts";
 
 export function buildSchemaFromTypeDefinitions(
   typeDefinitions: ITypeDefinitions,
   parseOptions?: GraphQLParseOptions
 ): any {
-  const document = buildDocumentFromTypeDefinitions(typeDefinitions, parseOptions);
+  const document = buildDocumentFromTypeDefinitions(
+    typeDefinitions,
+    parseOptions
+  );
   const typesAst = filterExtensionDefinitions(document);
 
   const backcompatOptions = { commentDescriptions: true };
@@ -23,7 +34,9 @@ export function buildSchemaFromTypeDefinitions(
   return schema;
 }
 
-export function isDocumentNode(typeDefinitions: ITypeDefinitions): typeDefinitions is any {
+export function isDocumentNode(
+  typeDefinitions: ITypeDefinitions
+): typeDefinitions is any {
   return (typeDefinitions as any).kind !== undefined;
 }
 
@@ -32,7 +45,7 @@ export function buildDocumentFromTypeDefinitions(
   parseOptions?: GraphQLParseOptions
 ): any {
   let document: any;
-  if (typeof typeDefinitions === 'string') {
+  if (typeof typeDefinitions === "string") {
     document = parse(typeDefinitions, parseOptions);
   } else if (Array.isArray(typeDefinitions)) {
     document = parse(concatenateTypeDefs(typeDefinitions), parseOptions);
@@ -40,7 +53,9 @@ export function buildDocumentFromTypeDefinitions(
     document = typeDefinitions;
   } else {
     const type = typeof typeDefinitions;
-    throw new Error(`typeDefs must be a string, array or schema AST, got ${type}`);
+    throw new Error(
+      `typeDefs must be a string, array or schema AST, got ${type}`
+    );
   }
 
   return document;

--- a/graphql-tools/schema/concatenateTypeDefs.ts
+++ b/graphql-tools/schema/concatenateTypeDefs.ts
@@ -1,31 +1,40 @@
 import { print } from "../../deps.ts";
 
-import { ITypedef } from '../utils/index.ts';
+import type { ITypedef } from "../utils/index.ts";
 
-export function concatenateTypeDefs(typeDefinitionsAry: Array<ITypedef>, calledFunctionRefs = [] as any): string {
+export function concatenateTypeDefs(
+  typeDefinitionsAry: Array<ITypedef>,
+  calledFunctionRefs = [] as any
+): string {
   let resolvedTypeDefinitions: Array<string> = [];
   typeDefinitionsAry.forEach((typeDef: ITypedef) => {
-    if (typeof typeDef === 'function') {
+    if (typeof typeDef === "function") {
       if (calledFunctionRefs.indexOf(typeDef) === -1) {
         calledFunctionRefs.push(typeDef);
-        resolvedTypeDefinitions = resolvedTypeDefinitions.concat(concatenateTypeDefs(typeDef(), calledFunctionRefs));
+        resolvedTypeDefinitions = resolvedTypeDefinitions.concat(
+          concatenateTypeDefs(typeDef(), calledFunctionRefs)
+        );
       }
-    } else if (typeof typeDef === 'string') {
+    } else if (typeof typeDef === "string") {
       resolvedTypeDefinitions.push(typeDef.trim());
     } else if ((typeDef as any).kind !== undefined) {
       resolvedTypeDefinitions.push(print(typeDef).trim());
     } else {
       const type = typeof typeDef;
-      throw new Error(`typeDef array must contain only strings, documents, or functions, got ${type}`);
+      throw new Error(
+        `typeDef array must contain only strings, documents, or functions, got ${type}`
+      );
     }
   });
-  return uniq(resolvedTypeDefinitions.map(x => x.trim())).join('\n');
+  return uniq(resolvedTypeDefinitions.map((x) => x.trim())).join("\n");
 }
 
 function uniq(array: Array<any>): Array<any> {
   return array.reduce(
     (accumulator, currentValue) =>
-      accumulator.indexOf(currentValue) === -1 ? [...accumulator, currentValue] : accumulator,
+      accumulator.indexOf(currentValue) === -1
+        ? [...accumulator, currentValue]
+        : accumulator,
     []
   );
 }

--- a/graphql-tools/schema/decorateWithLogger.ts
+++ b/graphql-tools/schema/decorateWithLogger.ts
@@ -1,5 +1,5 @@
 import { defaultFieldResolver } from "../../deps.ts";
-import { ILogger } from './types.ts';
+import type { ILogger } from "./types.ts";
 
 /*
  * fn: The function to decorate with the logger
@@ -19,7 +19,7 @@ export function decorateWithLogger(
     newE.stack = e.stack;
     /* istanbul ignore else: always get the hint from addErrorLoggingToSchema */
     if (hint) {
-      newE['originalMessage'] = e.message;
+      newE["originalMessage"] = e.message;
       newE.message = `Error in resolver ${hint}\n${e.message}`;
     }
     logger.log(newE);
@@ -29,7 +29,11 @@ export function decorateWithLogger(
     try {
       const result = resolver(root, args, ctx, info);
       // If the resolver returns a Promise log any Promise rejects.
-      if (result && typeof result.then === 'function' && typeof result.catch === 'function') {
+      if (
+        result &&
+        typeof result.then === "function" &&
+        typeof result.catch === "function"
+      ) {
         result.catch((reason: Error | string) => {
           // make sure that it's an error we're logging.
           const error = reason instanceof Error ? reason : new Error(reason);

--- a/graphql-tools/schema/extendResolversFromInterfaces.ts
+++ b/graphql-tools/schema/extendResolversFromInterfaces.ts
@@ -1,15 +1,18 @@
-import { IResolvers, IObjectTypeResolver } from '../utils/index.ts';
+import type { IResolvers, IObjectTypeResolver } from "../utils/index.ts";
 
-export function extendResolversFromInterfaces(schema: any, resolvers: IResolvers): IResolvers {
+export function extendResolversFromInterfaces(
+  schema: any,
+  resolvers: IResolvers
+): IResolvers {
   const typeNames = Object.keys({
     ...schema.getTypeMap(),
     ...resolvers,
   });
 
   const extendedResolvers: any = {};
-  typeNames.forEach(typeName => {
+  typeNames.forEach((typeName) => {
     const type: any = schema.getType(typeName);
-    if ('getInterfaces' in type) {
+    if ("getInterfaces" in type) {
       const allInterfaceResolvers = type
         .getInterfaces()
         .map((iFace: any) => resolvers[iFace.name])
@@ -17,14 +20,18 @@ export function extendResolversFromInterfaces(schema: any, resolvers: IResolvers
 
       extendedResolvers[typeName] = {};
       allInterfaceResolvers.forEach((interfaceResolvers: any) => {
-        Object.keys(interfaceResolvers).forEach(fieldName => {
-          if (fieldName === '__isTypeOf' || !fieldName.startsWith('__')) {
-            extendedResolvers[typeName][fieldName] = interfaceResolvers[fieldName];
+        Object.keys(interfaceResolvers).forEach((fieldName) => {
+          if (fieldName === "__isTypeOf" || !fieldName.startsWith("__")) {
+            extendedResolvers[typeName][fieldName] =
+              interfaceResolvers[fieldName];
           }
         });
       });
 
-      const typeResolvers = resolvers[typeName] as Record<string, IObjectTypeResolver>;
+      const typeResolvers = resolvers[typeName] as Record<
+        string,
+        IObjectTypeResolver
+      >;
       extendedResolvers[typeName] = {
         ...extendedResolvers[typeName],
         ...typeResolvers,

--- a/graphql-tools/schema/makeExecutableSchema.ts
+++ b/graphql-tools/schema/makeExecutableSchema.ts
@@ -1,13 +1,13 @@
-import { mergeDeep, SchemaDirectiveVisitor } from '../utils/index.ts';
-import { addResolversToSchema } from './addResolversToSchema.ts';
+import { mergeDeep, SchemaDirectiveVisitor } from "../utils/index.ts";
+import { addResolversToSchema } from "./addResolversToSchema.ts";
 
-import { attachDirectiveResolvers } from './attachDirectiveResolvers.ts';
-import { assertResolversPresent } from './assertResolversPresent.ts';
-import { addSchemaLevelResolver } from './addSchemaLevelResolver.ts';
-import { buildSchemaFromTypeDefinitions } from './buildSchemaFromTypeDefinitions.ts';
-import { addErrorLoggingToSchema } from './addErrorLoggingToSchema.ts';
-import { addCatchUndefinedToSchema } from './addCatchUndefinedToSchema.ts';
-import { IExecutableSchemaDefinition } from './types.ts';
+import { attachDirectiveResolvers } from "./attachDirectiveResolvers.ts";
+import { assertResolversPresent } from "./assertResolversPresent.ts";
+import { addSchemaLevelResolver } from "./addSchemaLevelResolver.ts";
+import { buildSchemaFromTypeDefinitions } from "./buildSchemaFromTypeDefinitions.ts";
+import { addErrorLoggingToSchema } from "./addErrorLoggingToSchema.ts";
+import { addCatchUndefinedToSchema } from "./addCatchUndefinedToSchema.ts";
+import type { IExecutableSchemaDefinition } from "./types.ts";
 
 export function makeExecutableSchema<TContext = any>({
   typeDefs,
@@ -22,16 +22,18 @@ export function makeExecutableSchema<TContext = any>({
   inheritResolversFromInterfaces = false,
 }: IExecutableSchemaDefinition<TContext>) {
   // Validate and clean up arguments
-  if (typeof resolverValidationOptions !== 'object') {
-    throw new Error('Expected `resolverValidationOptions` to be an object');
+  if (typeof resolverValidationOptions !== "object") {
+    throw new Error("Expected `resolverValidationOptions` to be an object");
   }
 
   if (!typeDefs) {
-    throw new Error('Must provide typeDefs');
+    throw new Error("Must provide typeDefs");
   }
 
   // We allow passing in an array of resolver maps, in which case we merge them
-  const resolverMap: any = Array.isArray(resolvers) ? resolvers.reduce(mergeDeep, {}) : resolvers;
+  const resolverMap: any = Array.isArray(resolvers)
+    ? resolvers.reduce(mergeDeep, {})
+    : resolvers;
 
   // Arguments are now validated and cleaned up
 
@@ -54,13 +56,16 @@ export function makeExecutableSchema<TContext = any>({
     schema = addErrorLoggingToSchema(schema, logger);
   }
 
-  if (typeof (resolvers as any)['__schema'] === 'function') {
+  if (typeof (resolvers as any)["__schema"] === "function") {
     // TODO a bit of a hack now, better rewrite generateSchema to attach it there.
     // not doing that now, because I'd have to rewrite a lot of tests.
-    schema = addSchemaLevelResolver(schema, (resolvers as any)['__schema'] as any);
+    schema = addSchemaLevelResolver(
+      schema,
+      (resolvers as any)["__schema"] as any
+    );
   }
 
-  schemaTransforms.forEach(schemaTransform => {
+  schemaTransforms.forEach((schemaTransform) => {
     schema = schemaTransform(schema);
   });
 

--- a/graphql-tools/schema/types.ts
+++ b/graphql-tools/schema/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ITypeDefinitions,
   IResolvers,
   IResolverValidationOptions,
@@ -6,7 +6,7 @@ import {
   SchemaDirectiveVisitorClass,
   GraphQLParseOptions,
   SchemaTransform,
-} from '../utils/index.ts';
+} from "../utils/index.ts";
 
 export interface ILogger {
   log: (error: Error) => void;

--- a/graphql-tools/utils/Interfaces.ts
+++ b/graphql-tools/utils/Interfaces.ts
@@ -1,4 +1,4 @@
-import { SchemaVisitor } from './SchemaVisitor.ts';
+import type { SchemaVisitor } from './SchemaVisitor.ts';
 
 // graphql-js < v15 backwards compatible ExecutionResult
 // See: https://github.com/graphql/graphql-js/pull/2490

--- a/graphql-tools/utils/SchemaDirectiveVisitor.ts
+++ b/graphql-tools/utils/SchemaDirectiveVisitor.ts
@@ -2,7 +2,7 @@ import { valueFromASTUntyped } from "../../deps.ts";
 
 import type { VisitableSchemaType } from "./Interfaces.ts";
 
-import type { SchemaVisitor } from "./SchemaVisitor.ts";
+import { SchemaVisitor } from "./SchemaVisitor.ts";
 import { visitSchema } from "./visitSchema.ts";
 import { getArgumentValues } from "./getArgumentValues.ts";
 

--- a/graphql-tools/utils/SchemaDirectiveVisitor.ts
+++ b/graphql-tools/utils/SchemaDirectiveVisitor.ts
@@ -1,12 +1,10 @@
-import {
-  valueFromASTUntyped,
-} from "../../deps.ts";
+import { valueFromASTUntyped } from "../../deps.ts";
 
-import { VisitableSchemaType } from './Interfaces.ts';
+import type { VisitableSchemaType } from "./Interfaces.ts";
 
-import { SchemaVisitor } from './SchemaVisitor.ts';
-import { visitSchema } from './visitSchema.ts';
-import { getArgumentValues } from './getArgumentValues.ts';
+import type { SchemaVisitor } from "./SchemaVisitor.ts";
+import { visitSchema } from "./visitSchema.ts";
+import { getArgumentValues } from "./getArgumentValues.ts";
 
 // This class represents a reusable implementation of a @directive that may
 // appear in a GraphQL schema written in Schema Definition Language.
@@ -51,7 +49,10 @@ import { getArgumentValues } from './getArgumentValues.ts';
 // parameter types, and more details about the properties exposed by instances
 // of the SchemaDirectiveVisitor class.
 
-export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaVisitor {
+export class SchemaDirectiveVisitor<
+  TArgs = any,
+  TContext = any
+> extends SchemaVisitor {
   // The name of the directive this visitor is allowed to visit (that is, the
   // identifier that appears after the @ character in the schema). Note that
   // this property is per-instance rather than static because subclasses of
@@ -108,7 +109,10 @@ export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaV
     // If the schema declares any directives for public consumption, record
     // them here so that we can properly coerce arguments when/if we encounter
     // an occurrence of the directive while walking the schema below.
-    const declaredDirectives = this.getDeclaredDirectives(schema, directiveVisitors);
+    const declaredDirectives = this.getDeclaredDirectives(
+      schema,
+      directiveVisitors
+    );
 
     // Map from directive names to lists of SchemaDirectiveVisitor instances
     // created while visiting the schema.
@@ -128,7 +132,10 @@ export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaV
       {}
     );
 
-    function visitorSelector(type: VisitableSchemaType, methodName: string): Array<SchemaDirectiveVisitor> {
+    function visitorSelector(
+      type: VisitableSchemaType,
+      methodName: string
+    ): Array<SchemaDirectiveVisitor> {
       let directiveNodes = type?.astNode?.directives ?? [];
 
       const extensionASTNodes: any = (type as {
@@ -194,7 +201,7 @@ export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaV
       });
 
       if (visitors.length > 0) {
-        visitors.forEach(visitor => {
+        visitors.forEach((visitor) => {
           createdVisitors[visitor.name].push(visitor);
         });
       }
@@ -211,7 +218,10 @@ export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaV
     schema: any,
     directiveVisitors: Record<string, SchemaDirectiveVisitorClass>
   ): Record<string, any> {
-    const declaredDirectives: Record<string, any> = schema.getDirectives().reduce(
+    const declaredDirectives: Record<
+      string,
+      any
+    > = schema.getDirectives().reduce(
       (prev: any, curr: any) => ({
         ...prev,
         [curr.name]: curr,
@@ -223,12 +233,17 @@ export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaV
     // declared in the schema itself. Reasoning: if a SchemaDirectiveVisitor
     // goes to the trouble of implementing getDirectiveDeclaration, it should
     // be able to rely on that implementation.
-    Object.entries(directiveVisitors).forEach(([directiveName, visitorClass]) => {
-      const decl = visitorClass.getDirectiveDeclaration(directiveName, schema);
-      if (decl != null) {
-        declaredDirectives[directiveName] = decl;
+    Object.entries(directiveVisitors).forEach(
+      ([directiveName, visitorClass]) => {
+        const decl = visitorClass.getDirectiveDeclaration(
+          directiveName,
+          schema
+        );
+        if (decl != null) {
+          declaredDirectives[directiveName] = decl;
+        }
       }
-    });
+    );
 
     Object.entries(declaredDirectives).forEach(([name, decl]) => {
       if (!(name in directiveVisitors)) {
@@ -250,7 +265,9 @@ export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaV
           // it's definitely a mistake if the GraphQLDirective declares itself
           // applicable to certain schema locations, and the visitor subclass
           // does not implement all the corresponding methods.
-          throw new Error(`SchemaDirectiveVisitor for @${name} must implement ${visitorMethodName} method`);
+          throw new Error(
+            `SchemaDirectiveVisitor for @${name} must implement ${visitorMethodName} method`
+          );
         }
       });
     });
@@ -279,8 +296,12 @@ export class SchemaDirectiveVisitor<TArgs = any, TContext = any> extends SchemaV
 // Convert a string like "FIELD_DEFINITION" to "visitFieldDefinition".
 function directiveLocationToVisitorMethodName(loc: any) {
   return (
-    'visit' +
-    loc.replace(/([^_]*)_?/g, (_wholeMatch: any, part: string) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    "visit" +
+    loc.replace(
+      /([^_]*)_?/g,
+      (_wholeMatch: any, part: string) =>
+        part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+    )
   );
 }
 

--- a/graphql-tools/utils/collectFields.ts
+++ b/graphql-tools/utils/collectFields.ts
@@ -7,7 +7,7 @@ import {
   isAbstractType,
 } from "../../deps.ts";
 
-import { GraphQLExecutionContext } from './Interfaces.ts';
+import type { GraphQLExecutionContext } from "./Interfaces.ts";
 
 /**
  * Given a selectionSet, adds all of the fields in that selection to
@@ -46,20 +46,38 @@ export function collectFields(
         ) {
           continue;
         }
-        collectFields(exeContext, runtimeType, selection.selectionSet, fields, visitedFragmentNames);
+        collectFields(
+          exeContext,
+          runtimeType,
+          selection.selectionSet,
+          fields,
+          visitedFragmentNames
+        );
         break;
       }
       case Kind.FRAGMENT_SPREAD: {
         const fragName = selection.name.value;
-        if (visitedFragmentNames[fragName] || !shouldIncludeNode(exeContext, selection)) {
+        if (
+          visitedFragmentNames[fragName] ||
+          !shouldIncludeNode(exeContext, selection)
+        ) {
           continue;
         }
         visitedFragmentNames[fragName] = true;
         const fragment = exeContext.fragments[fragName];
-        if (!fragment || !doesFragmentConditionMatch(exeContext, fragment, runtimeType)) {
+        if (
+          !fragment ||
+          !doesFragmentConditionMatch(exeContext, fragment, runtimeType)
+        ) {
           continue;
         }
-        collectFields(exeContext, runtimeType, fragment.selectionSet, fields, visitedFragmentNames);
+        collectFields(
+          exeContext,
+          runtimeType,
+          fragment.selectionSet,
+          fields,
+          visitedFragmentNames
+        );
         break;
       }
     }
@@ -75,13 +93,21 @@ function shouldIncludeNode(
   exeContext: GraphQLExecutionContext,
   node: any
 ): boolean {
-  const skip: any = getDirectiveValues(GraphQLSkipDirective, node, exeContext.variableValues);
+  const skip: any = getDirectiveValues(
+    GraphQLSkipDirective,
+    node,
+    exeContext.variableValues
+  );
 
   if (skip?.if === true) {
     return false;
   }
 
-  const include: any = getDirectiveValues(GraphQLIncludeDirective, node, exeContext.variableValues);
+  const include: any = getDirectiveValues(
+    GraphQLIncludeDirective,
+    node,
+    exeContext.variableValues
+  );
 
   if (include?.if === false) {
     return false;

--- a/graphql-tools/utils/fix-schema-ast.ts
+++ b/graphql-tools/utils/fix-schema-ast.ts
@@ -1,6 +1,6 @@
 import { buildSchema } from "../../deps.ts";
-import { SchemaPrintOptions } from './types.ts';
-import { printSchemaWithDirectives } from './print-schema-with-directives.ts';
+import type { SchemaPrintOptions } from "./types.ts";
+import { printSchemaWithDirectives } from "./print-schema-with-directives.ts";
 
 function buildFixedSchema(schema: any, options: any & SchemaPrintOptions) {
   return buildSchema(printSchemaWithDirectives(schema, options), {
@@ -12,7 +12,7 @@ function buildFixedSchema(schema: any, options: any & SchemaPrintOptions) {
 export function fixSchemaAst(schema: any, options: any & SchemaPrintOptions) {
   let schemaWithValidAst: any;
   if (!schema.astNode) {
-    Object.defineProperty(schema, 'astNode', {
+    Object.defineProperty(schema, "astNode", {
       get() {
         if (!schemaWithValidAst) {
           schemaWithValidAst = buildFixedSchema(schema, options);
@@ -22,7 +22,7 @@ export function fixSchemaAst(schema: any, options: any & SchemaPrintOptions) {
     });
   }
   if (!schema.extensionASTNodes) {
-    Object.defineProperty(schema, 'extensionASTNodes', {
+    Object.defineProperty(schema, "extensionASTNodes", {
       get() {
         if (!schemaWithValidAst) {
           schemaWithValidAst = buildFixedSchema(schema, options);

--- a/graphql-tools/utils/forEachDefaultValue.ts
+++ b/graphql-tools/utils/forEachDefaultValue.ts
@@ -1,16 +1,19 @@
 import { getNamedType, isObjectType, isInputObjectType } from "../../deps.ts";
 
-import { IDefaultValueIteratorFn } from './Interfaces.ts';
+import type { IDefaultValueIteratorFn } from "./Interfaces.ts";
 
-export function forEachDefaultValue(schema: any, fn: IDefaultValueIteratorFn): void {
+export function forEachDefaultValue(
+  schema: any,
+  fn: IDefaultValueIteratorFn
+): void {
   const typeMap = schema.getTypeMap();
-  Object.keys(typeMap).forEach(typeName => {
+  Object.keys(typeMap).forEach((typeName) => {
     const type = typeMap[typeName];
 
-    if (!(getNamedType(type) as any).name.startsWith('__')) {
+    if (!(getNamedType(type) as any).name.startsWith("__")) {
       if (isObjectType(type)) {
         const fields = type.getFields();
-        Object.keys(fields).forEach(fieldName => {
+        Object.keys(fields).forEach((fieldName) => {
           const field = fields[fieldName];
 
           field.args.forEach((arg: any) => {
@@ -19,7 +22,7 @@ export function forEachDefaultValue(schema: any, fn: IDefaultValueIteratorFn): v
         });
       } else if (isInputObjectType(type)) {
         const fields = type.getFields();
-        Object.keys(fields).forEach(fieldName => {
+        Object.keys(fields).forEach((fieldName) => {
           const field = fields[fieldName];
           field.defaultValue = fn(field.type, field.defaultValue);
         });

--- a/graphql-tools/utils/forEachField.ts
+++ b/graphql-tools/utils/forEachField.ts
@@ -1,16 +1,19 @@
 import { getNamedType, isObjectType } from "../../deps.ts";
 
-import { IFieldIteratorFn } from './Interfaces.ts';
+import type { IFieldIteratorFn } from "./Interfaces.ts";
 
 export function forEachField(schema: any, fn: IFieldIteratorFn): void {
   const typeMap = schema.getTypeMap();
-  Object.keys(typeMap).forEach(typeName => {
+  Object.keys(typeMap).forEach((typeName) => {
     const type = typeMap[typeName];
 
     // TODO: maybe have an option to include these?
-    if (!(getNamedType(type) as any).name.startsWith('__') && isObjectType(type)) {
+    if (
+      !(getNamedType(type) as any).name.startsWith("__") &&
+      isObjectType(type)
+    ) {
       const fields = type.getFields();
-      Object.keys(fields).forEach(fieldName => {
+      Object.keys(fields).forEach((fieldName) => {
         const field = fields[fieldName];
         fn(field, typeName, fieldName);
       });

--- a/graphql-tools/utils/getResolversFromSchema.ts
+++ b/graphql-tools/utils/getResolversFromSchema.ts
@@ -7,16 +7,16 @@ import {
   isSpecifiedScalarType,
 } from "../../deps.ts";
 
-import { IResolvers } from './Interfaces.ts';
+import type { IResolvers } from "./Interfaces.ts";
 
-import { cloneType } from './clone.ts';
+import { cloneType } from "./clone.ts";
 
 export function getResolversFromSchema(schema: any): IResolvers {
   const resolvers = Object.create({});
 
   const typeMap = schema.getTypeMap();
 
-  Object.keys(typeMap).forEach(typeName => {
+  Object.keys(typeMap).forEach((typeName) => {
     const type = typeMap[typeName];
 
     if (isScalarType(type)) {
@@ -50,7 +50,7 @@ export function getResolversFromSchema(schema: any): IResolvers {
       }
 
       const fields = type.getFields();
-      Object.keys(fields).forEach(fieldName => {
+      Object.keys(fields).forEach((fieldName) => {
         const field = fields[fieldName];
 
         resolvers[typeName][fieldName] = {

--- a/graphql-tools/utils/heal.ts
+++ b/graphql-tools/utils/heal.ts
@@ -11,7 +11,7 @@ import {
   isNonNullType,
 } from "../../deps.ts";
 
-import { TypeMap } from './Interfaces.ts';
+import type { TypeMap } from './Interfaces.ts';
 
 // Update any references to named schema types that disagree with the named
 // types found in schema.getTypeMap().

--- a/graphql-tools/utils/parse-graphql-json.ts
+++ b/graphql-tools/utils/parse-graphql-json.ts
@@ -1,7 +1,7 @@
 import { buildClientSchema, parse } from "../../deps.ts";
 // import { GraphQLSchemaValidationOptions } from 'graphql/type/schema';
 import { printSchemaWithDirectives } from "./print-schema-with-directives.ts";
-import { Source } from "./loaders.ts";
+import type { Source } from "./loaders.ts";
 import type { SchemaPrintOptions } from "./types.ts";
 
 function stripBOM(content: string): string {

--- a/graphql-tools/utils/parse-graphql-json.ts
+++ b/graphql-tools/utils/parse-graphql-json.ts
@@ -1,8 +1,8 @@
 import { buildClientSchema, parse } from "../../deps.ts";
 // import { GraphQLSchemaValidationOptions } from 'graphql/type/schema';
-import { printSchemaWithDirectives } from './print-schema-with-directives.ts';
-import { Source } from './loaders.ts';
-import { SchemaPrintOptions } from './types.ts';
+import { printSchemaWithDirectives } from "./print-schema-with-directives.ts";
+import { Source } from "./loaders.ts";
+import type { SchemaPrintOptions } from "./types.ts";
 
 function stripBOM(content: string): string {
   content = content.toString();
@@ -31,7 +31,7 @@ export function parseGraphQLJSON(
     parsedJson = parsedJson.data;
   }
 
-  if (parsedJson.kind === 'Document') {
+  if (parsedJson.kind === "Document") {
     const document = parsedJson;
 
     return {
@@ -39,7 +39,7 @@ export function parseGraphQLJSON(
       document,
     };
   } else if (parsedJson.__schema) {
-    const schema = buildClientSchema(parsedJson, (options as any));
+    const schema = buildClientSchema(parsedJson, options as any);
     const rawSDL = printSchemaWithDirectives(schema, options);
 
     return {

--- a/graphql-tools/utils/print-schema-with-directives.ts
+++ b/graphql-tools/utils/print-schema-with-directives.ts
@@ -7,17 +7,21 @@ import {
   isScalarType,
   parse,
 } from "../../deps.ts";
-import { SchemaPrintOptions } from './types.ts';
-import { createSchemaDefinition } from './create-schema-definition.ts';
+import type { SchemaPrintOptions } from "./types.ts";
+import { createSchemaDefinition } from "./create-schema-definition.ts";
 
-export function printSchemaWithDirectives(schema: any, _options: SchemaPrintOptions = {}): string {
+export function printSchemaWithDirectives(
+  schema: any,
+  _options: SchemaPrintOptions = {}
+): string {
   const typesMap = schema.getTypeMap();
 
   const result: any = [getSchemaDefinition(schema)];
 
   for (const typeName in typesMap) {
     const type = typesMap[typeName];
-    const isPredefinedScalar = isScalarType(type) && isSpecifiedScalarType(type);
+    const isPredefinedScalar =
+      isScalarType(type) && isSpecifiedScalarType(type);
     const isIntrospection = isIntrospectionType(type);
 
     if (isPredefinedScalar || isIntrospection) {
@@ -35,7 +39,7 @@ export function printSchemaWithDirectives(schema: any, _options: SchemaPrintOpti
     }
   }
 
-  return result.join('\n');
+  return result.join("\n");
 }
 
 function extendDefinition(type: any): any {
@@ -65,27 +69,34 @@ function extendDefinition(type: any): any {
   }
 }
 
-function correctType<TMap extends { [key: string]: any }, TName extends keyof TMap>(
-  typeName: TName,
-  typesMap: TMap
-): any {
+function correctType<
+  TMap extends { [key: string]: any },
+  TName extends keyof TMap
+>(typeName: TName, typesMap: TMap): any {
   const type = typesMap[typeName];
 
   type.name = typeName.toString();
 
   if (type.astNode && type.extensionASTNodes) {
-    type.astNode = type.extensionASTNodes ? extendDefinition(type) : type.astNode;
+    type.astNode = type.extensionASTNodes
+      ? extendDefinition(type)
+      : type.astNode;
   }
   const doc: any = (parse as any)((printType as any)(type));
   const fixedAstNode: any = doc.definitions[0] as any;
   const originalAstNode: any = type?.astNode;
   if (originalAstNode) {
     (fixedAstNode.directives as any[]) = originalAstNode?.directives as any[];
-    if ('fields' in fixedAstNode && 'fields' in originalAstNode) {
+    if ("fields" in fixedAstNode && "fields" in originalAstNode) {
       for (const fieldDefinitionNode of fixedAstNode.fields) {
-        const originalFieldDefinitionNode: any = (originalAstNode.fields as any).find((field: any) => field.name.value === fieldDefinitionNode.name.value);
+        const originalFieldDefinitionNode: any = (originalAstNode.fields as any).find(
+          (field: any) => field.name.value === fieldDefinitionNode.name.value
+        );
         (fieldDefinitionNode.directives as any[]) = originalFieldDefinitionNode?.directives as any[];
-        if ('arguments' in fieldDefinitionNode && 'arguments' in originalFieldDefinitionNode) {
+        if (
+          "arguments" in fieldDefinitionNode &&
+          "arguments" in originalFieldDefinitionNode
+        ) {
           for (const argument of fieldDefinitionNode.arguments) {
             const originalArgumentNode: any = (originalFieldDefinitionNode as any).arguments?.find(
               (arg: any) => arg.name.value === argument.name.value
@@ -94,10 +105,10 @@ function correctType<TMap extends { [key: string]: any }, TName extends keyof TM
           }
         }
       }
-    } else if ('values' in fixedAstNode && 'values' in originalAstNode) {
+    } else if ("values" in fixedAstNode && "values" in originalAstNode) {
       for (const valueDefinitionNode of fixedAstNode.values) {
         const originalValueDefinitionNode = (originalAstNode.values as any[]).find(
-          valueNode => valueNode.name.value === valueDefinitionNode.name.value
+          (valueNode) => valueNode.name.value === valueDefinitionNode.name.value
         );
         (valueDefinitionNode.directives as any[]) = originalValueDefinitionNode?.directives as any[];
       }
@@ -109,7 +120,10 @@ function correctType<TMap extends { [key: string]: any }, TName extends keyof TM
 }
 
 function getSchemaDefinition(schema: any) {
-  if (!(Object.getOwnPropertyDescriptor(schema, 'astNode') as any).get && schema.astNode) {
+  if (
+    !(Object.getOwnPropertyDescriptor(schema, "astNode") as any).get &&
+    schema.astNode
+  ) {
     return print(schema.astNode);
   } else {
     return createSchemaDefinition({

--- a/graphql-tools/utils/rewire.ts
+++ b/graphql-tools/utils/rewire.ts
@@ -20,8 +20,8 @@ import {
   isSpecifiedScalarType,
 } from "../../deps.ts";
 
-import { getBuiltInForStub, isNamedStub } from './stub.ts';
-import { TypeMap } from './Interfaces.ts';
+import { getBuiltInForStub, isNamedStub } from "./stub.ts";
+import type { TypeMap } from "./Interfaces.ts";
 
 export function rewireTypes(
   originalTypeMap: Record<string, any | null>,
@@ -37,15 +37,15 @@ export function rewireTypes(
 } {
   const newTypeMap: TypeMap = Object.create(null);
 
-  Object.keys(originalTypeMap).forEach(typeName => {
+  Object.keys(originalTypeMap).forEach((typeName) => {
     const namedType = originalTypeMap[typeName];
 
-    if (namedType == null || typeName.startsWith('__')) {
+    if (namedType == null || typeName.startsWith("__")) {
       return;
     }
 
     const newName = namedType.name;
-    if (newName.startsWith('__')) {
+    if (newName.startsWith("__")) {
       return;
     }
 
@@ -56,11 +56,13 @@ export function rewireTypes(
     newTypeMap[newName] = namedType;
   });
 
-  Object.keys(newTypeMap).forEach(typeName => {
+  Object.keys(newTypeMap).forEach((typeName) => {
     newTypeMap[typeName] = rewireNamedType(newTypeMap[typeName]);
   });
 
-  const newDirectives = directives.map(directive => rewireDirective(directive));
+  const newDirectives = directives.map((directive) =>
+    rewireDirective(directive)
+  );
 
   return options.skipPruning
     ? {
@@ -77,7 +79,7 @@ export function rewireTypes(
 
   function rewireArgs(args: any): any {
     const rewiredArgs: any = {};
-    Object.keys(args).forEach(argName => {
+    Object.keys(args).forEach((argName) => {
       const arg = args[argName];
       const rewiredArgType = rewireType(arg.type);
       if (rewiredArgType != null) {
@@ -103,9 +105,11 @@ export function rewireTypes(
         ...config,
         fields: () => rewireFields(config.fields),
       };
-      if ('interfaces' in newConfig) {
+      if ("interfaces" in newConfig) {
         newConfig.interfaces = () =>
-          rewireNamedTypes(((config as unknown) as { interfaces: Array<any> }).interfaces);
+          rewireNamedTypes(
+            ((config as unknown) as { interfaces: Array<any> }).interfaces
+          );
       }
       return new (GraphQLInterfaceType as any)(newConfig);
     } else if (isUnionType(type)) {
@@ -138,7 +142,7 @@ export function rewireTypes(
 
   function rewireFields(fields: any): any {
     const rewiredFields: any = {};
-    Object.keys(fields).forEach(fieldName => {
+    Object.keys(fields).forEach((fieldName) => {
       const field: any = fields[fieldName];
       const rewiredFieldType = rewireType(field.type);
       if (rewiredFieldType != null) {
@@ -152,7 +156,7 @@ export function rewireTypes(
 
   function rewireInputFields(fields: any): any {
     const rewiredFields: any = {};
-    Object.keys(fields).forEach(fieldName => {
+    Object.keys(fields).forEach((fieldName) => {
       const field = fields[fieldName];
       const rewiredFieldType = rewireType(field.type);
       if (rewiredFieldType != null) {
@@ -165,7 +169,7 @@ export function rewireTypes(
 
   function rewireNamedTypes<T extends any>(namedTypes: Array<T>): Array<T> {
     const rewiredTypes: Array<T> = [];
-    namedTypes.forEach(namedType => {
+    namedTypes.forEach((namedType) => {
       const rewiredType = rewireType(namedType);
       if (rewiredType != null) {
         rewiredTypes.push(rewiredType);
@@ -177,10 +181,14 @@ export function rewireTypes(
   function rewireType<T extends any>(type: any): any {
     if (isListType(type)) {
       const rewiredType = rewireType(type.ofType);
-      return rewiredType != null ? (new (GraphQLList as any)(rewiredType) as T) : null;
+      return rewiredType != null
+        ? (new (GraphQLList as any)(rewiredType) as T)
+        : null;
     } else if (isNonNullType(type)) {
       const rewiredType = rewireType(type.ofType);
-      return rewiredType != null ? (new (GraphQLNonNull as any)(rewiredType) as T) : null;
+      return rewiredType != null
+        ? (new (GraphQLNonNull as any)(rewiredType) as T)
+        : null;
     } else if (isNamedType(type)) {
       let rewiredType = originalTypeMap[type.name];
       if (rewiredType === undefined) {
@@ -204,10 +212,10 @@ function pruneTypes(
   const newTypeMap: any = {};
 
   const implementedInterfaces: any = {};
-  Object.keys(typeMap).forEach(typeName => {
+  Object.keys(typeMap).forEach((typeName) => {
     const namedType = typeMap[typeName];
 
-    if ('getInterfaces' in namedType) {
+    if ("getInterfaces" in namedType) {
       namedType.getInterfaces().forEach((iface: any) => {
         implementedInterfaces[iface.name] = true;
       });
@@ -235,7 +243,10 @@ function pruneTypes(
       }
     } else if (isInterfaceType(type)) {
       // prune interfaces without fields or without implementations
-      if (Object.keys(type.getFields()).length && implementedInterfaces[type.name]) {
+      if (
+        Object.keys(type.getFields()).length &&
+        implementedInterfaces[type.name]
+      ) {
         newTypeMap[typeName] = type;
       } else {
         prunedTypeMap = true;
@@ -246,5 +257,7 @@ function pruneTypes(
   }
 
   // every prune requires another round of healing
-  return prunedTypeMap ? rewireTypes(newTypeMap, directives) : { typeMap, directives };
+  return prunedTypeMap
+    ? rewireTypes(newTypeMap, directives)
+    : { typeMap, directives };
 }

--- a/graphql-tools/utils/transforms.ts
+++ b/graphql-tools/utils/transforms.ts
@@ -1,30 +1,45 @@
 import { GraphQLSchema } from "../../deps.ts";
 
-import { Request, Transform } from './Interfaces.ts';
+import type { Request, Transform } from "./Interfaces.ts";
 
-import { cloneSchema } from './clone.ts';
+import { cloneSchema } from "./clone.ts";
 
-export function applySchemaTransforms(originalSchema: any, transforms: Array<Transform>): any {
+export function applySchemaTransforms(
+  originalSchema: any,
+  transforms: Array<Transform>
+): any {
   return transforms.reduce(
     (schema: any, transform: Transform) =>
-      transform.transformSchema != null ? transform.transformSchema(cloneSchema(schema)) : schema,
+      transform.transformSchema != null
+        ? transform.transformSchema(cloneSchema(schema))
+        : schema,
     originalSchema
   );
 }
 
-export function applyRequestTransforms(originalRequest: Request, transforms: Array<Transform>): Request {
+export function applyRequestTransforms(
+  originalRequest: Request,
+  transforms: Array<Transform>
+): Request {
   return transforms.reduce(
     (request: Request, transform: Transform) =>
-      transform.transformRequest != null ? transform.transformRequest(request) : request,
+      transform.transformRequest != null
+        ? transform.transformRequest(request)
+        : request,
 
     originalRequest
   );
 }
 
-export function applyResultTransforms(originalResult: any, transforms: Array<Transform>): any {
+export function applyResultTransforms(
+  originalResult: any,
+  transforms: Array<Transform>
+): any {
   return transforms.reduceRight(
     (result: any, transform: Transform) =>
-      transform.transformResult != null ? transform.transformResult(result) : result,
+      transform.transformResult != null
+        ? transform.transformResult(result)
+        : result,
     originalResult
   );
 }

--- a/graphql-tools/utils/validate-documents.ts
+++ b/graphql-tools/utils/validate-documents.ts
@@ -1,10 +1,6 @@
-import {
-  Kind,
-  validate,
-  specifiedRules,
-} from "../../deps.ts";
-import { Source } from './loaders.ts';
-import { CombinedError } from './errors.ts';
+import { Kind, validate, specifiedRules } from "../../deps.ts";
+import type { Source } from "./loaders.ts";
+import { CombinedError } from "./errors.ts";
 
 export type ValidationRule = (context: any) => any;
 const DEFAULT_EFFECTIVE_RULES = createDefaultRules();
@@ -21,7 +17,7 @@ export async function validateGraphQlDocuments(
 ): Promise<ReadonlyArray<LoadDocumentError>> {
   const allFragments: any[] = [];
 
-  documentFiles.forEach(documentFile => {
+  documentFiles.forEach((documentFile) => {
     if (documentFile.document) {
       for (const definitionNode of documentFile.document.definitions) {
         if (definitionNode.kind === Kind.FRAGMENT_DEFINITION) {
@@ -37,10 +33,15 @@ export async function validateGraphQlDocuments(
     documentFiles.map(async (documentFile: any) => {
       const documentToValidate = {
         kind: Kind.DOCUMENT,
-        definitions: [...allFragments, ...documentFile.document.definitions].filter((definition, index, list) => {
+        definitions: [
+          ...allFragments,
+          ...documentFile.document.definitions,
+        ].filter((definition, index, list) => {
           if (definition.kind === Kind.FRAGMENT_DEFINITION) {
             const firstIndex = list.findIndex(
-              def => def.kind === Kind.FRAGMENT_DEFINITION && def.name.value === definition.name.value
+              (def) =>
+                def.kind === Kind.FRAGMENT_DEFINITION &&
+                def.name.value === definition.name.value
             );
             const isDuplicated = firstIndex !== index;
 
@@ -53,7 +54,11 @@ export async function validateGraphQlDocuments(
         }),
       };
 
-      const errors = (validate as any)(schema, documentToValidate, effectiveRules);
+      const errors = (validate as any)(
+        schema,
+        documentToValidate,
+        effectiveRules
+      );
 
       if (errors.length > 0) {
         allErrors.push({
@@ -67,18 +72,21 @@ export async function validateGraphQlDocuments(
   return allErrors;
 }
 
-export function checkValidationErrors(loadDocumentErrors: ReadonlyArray<LoadDocumentError>): void | never {
+export function checkValidationErrors(
+  loadDocumentErrors: ReadonlyArray<LoadDocumentError>
+): void | never {
   if (loadDocumentErrors.length > 0) {
     const errors: Error[] = [];
 
     for (const loadDocumentError of loadDocumentErrors) {
       for (const graphQLError of loadDocumentError.errors) {
         const error = new Error();
-        error.name = 'GraphQLDocumentError';
+        error.name = "GraphQLDocumentError";
         error.message = `${error.name}: ${graphQLError.message}`;
         error.stack = error.message;
         (graphQLError as any).locations.forEach(
-          (location: any) => (error.stack += `\n    at ${loadDocumentError.filePath}:${location.line}:${location.column}`)
+          (location: any) =>
+            (error.stack += `\n    at ${loadDocumentError.filePath}:${location.line}:${location.column}`)
         );
 
         errors.push(error);
@@ -90,13 +98,19 @@ export function checkValidationErrors(loadDocumentErrors: ReadonlyArray<LoadDocu
 }
 
 function createDefaultRules() {
-  const ignored = ['NoUnusedFragmentsRule', 'NoUnusedVariablesRule', 'KnownDirectivesRule'];
+  const ignored = [
+    "NoUnusedFragmentsRule",
+    "NoUnusedVariablesRule",
+    "KnownDirectivesRule",
+  ];
 
   // GraphQL v14 has no Rule suffix in function names
   // Adding `*Rule` makes validation backwards compatible
-  ignored.forEach(rule => {
-    ignored.push(rule.replace(/Rule$/, ''));
+  ignored.forEach((rule) => {
+    ignored.push(rule.replace(/Rule$/, ""));
   });
 
-  return specifiedRules.filter((f: (...args: any[]) => any) => !ignored.includes(f.name));
+  return specifiedRules.filter(
+    (f: (...args: any[]) => any) => !ignored.includes(f.name)
+  );
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
+import { GraphQLError, gql, PubSub } from "./deps.ts";
 
-import { GraphQLError, gql, PubSub } from "./deps.ts"
-
-export { gql, PubSub }
+export { gql, PubSub };
 export const GQLError = GraphQLError as any;
-export { applyGraphQL, ApplyGraphQLOptions, ResolversProps } from "./applyGraphQL.ts";
+export { applyGraphQL } from "./applyGraphQL.ts";
+export type { ApplyGraphQLOptions, ResolversProps } from "./applyGraphQL.ts";


### PR DESCRIPTION
imports and exports not as values require to be done with `import type` and `export type`. 
With this PR it works just fine with TypeScript 4 and Deno 1.4.0