### PR TITLE
Use type-only imports and exports

### DIFF
--- a/graphql-subscriptions/index.ts
+++ b/graphql-subscriptions/index.ts
@@ -1,3 +1,5 @@
 export { PubSubEngine } from './pubsub-engine.ts';
-export { PubSub, PubSubOptions } from './pubsub.ts';
-export { withFilter, ResolverFn, FilterFn } from './with-filter.ts';
+export { PubSub } from './pubsub.ts';
+export type { PubSubOptions } from './pubsub.ts';
+export { withFilter } from './with-filter.ts';
+export type { ResolverFn, FilterFn } from './with-filter.ts';

--- a/graphql-subscriptions/pubsub-async-iterator.ts
+++ b/graphql-subscriptions/pubsub-async-iterator.ts
@@ -1,5 +1,5 @@
 import { $$asyncIterator } from "https://cdn.pika.dev/iterall@^1.3.0";
-import { PubSubEngine } from './pubsub-engine.ts';
+import type { PubSubEngine } from './pubsub-engine.ts';
 
 /**
  * A class for digesting PubSubEngine events via the new AsyncIterator interface.

--- a/graphql-tools/schema/addErrorLoggingToSchema.ts
+++ b/graphql-tools/schema/addErrorLoggingToSchema.ts
@@ -1,6 +1,6 @@
 import { mapSchema, MapperKind } from '../utils/index.ts';
 import { decorateWithLogger } from './decorateWithLogger.ts';
-import { ILogger } from './types.ts';
+import type { ILogger } from './types.ts';
 
 export function addErrorLoggingToSchema(schema: any, logger?: ILogger): any {
   if (!logger) {

--- a/graphql-tools/schema/buildSchemaFromTypeDefinitions.ts
+++ b/graphql-tools/schema/buildSchemaFromTypeDefinitions.ts
@@ -1,6 +1,6 @@
-import { parse, extendSchema, buildASTSchema, GraphQLSchema, } from "../../deps.ts";
+import { parse, extendSchema, buildASTSchema } from "../../deps.ts";
 
-import { ITypeDefinitions, GraphQLParseOptions } from '../utils/index.ts';
+import type { ITypeDefinitions, GraphQLParseOptions } from '../utils/index.ts';
 
 import { extractExtensionDefinitions, filterExtensionDefinitions } from './extensionDefinitions.ts';
 import { concatenateTypeDefs } from './concatenateTypeDefs.ts';

--- a/graphql-tools/schema/concatenateTypeDefs.ts
+++ b/graphql-tools/schema/concatenateTypeDefs.ts
@@ -1,6 +1,6 @@
 import { print } from "../../deps.ts";
 
-import { ITypedef } from '../utils/index.ts';
+import type { ITypedef } from '../utils/index.ts';
 
 export function concatenateTypeDefs(typeDefinitionsAry: Array<ITypedef>, calledFunctionRefs = [] as any): string {
   let resolvedTypeDefinitions: Array<string> = [];

--- a/graphql-tools/schema/decorateWithLogger.ts
+++ b/graphql-tools/schema/decorateWithLogger.ts
@@ -1,5 +1,5 @@
 import { defaultFieldResolver } from "../../deps.ts";
-import { ILogger } from './types.ts';
+import type { ILogger } from './types.ts';
 
 /*
  * fn: The function to decorate with the logger

--- a/graphql-tools/schema/extendResolversFromInterfaces.ts
+++ b/graphql-tools/schema/extendResolversFromInterfaces.ts
@@ -1,4 +1,4 @@
-import { IResolvers, IObjectTypeResolver } from '../utils/index.ts';
+import type { IResolvers, IObjectTypeResolver } from '../utils/index.ts';
 
 export function extendResolversFromInterfaces(schema: any, resolvers: IResolvers): IResolvers {
   const typeNames = Object.keys({

--- a/graphql-tools/schema/makeExecutableSchema.ts
+++ b/graphql-tools/schema/makeExecutableSchema.ts
@@ -7,7 +7,7 @@ import { addSchemaLevelResolver } from './addSchemaLevelResolver.ts';
 import { buildSchemaFromTypeDefinitions } from './buildSchemaFromTypeDefinitions.ts';
 import { addErrorLoggingToSchema } from './addErrorLoggingToSchema.ts';
 import { addCatchUndefinedToSchema } from './addCatchUndefinedToSchema.ts';
-import { IExecutableSchemaDefinition } from './types.ts';
+import type { IExecutableSchemaDefinition } from './types.ts';
 
 export function makeExecutableSchema<TContext = any>({
   typeDefs,

--- a/graphql-tools/schema/types.ts
+++ b/graphql-tools/schema/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ITypeDefinitions,
   IResolvers,
   IResolverValidationOptions,

--- a/graphql-tools/utils/Interfaces.ts
+++ b/graphql-tools/utils/Interfaces.ts
@@ -1,4 +1,4 @@
-import { SchemaVisitor } from './SchemaVisitor.ts';
+import type { SchemaVisitor } from './SchemaVisitor.ts';
 
 // graphql-js < v15 backwards compatible ExecutionResult
 // See: https://github.com/graphql/graphql-js/pull/2490

--- a/graphql-tools/utils/SchemaDirectiveVisitor.ts
+++ b/graphql-tools/utils/SchemaDirectiveVisitor.ts
@@ -2,7 +2,7 @@ import {
   valueFromASTUntyped,
 } from "../../deps.ts";
 
-import { VisitableSchemaType } from './Interfaces.ts';
+import type { VisitableSchemaType } from './Interfaces.ts';
 
 import { SchemaVisitor } from './SchemaVisitor.ts';
 import { visitSchema } from './visitSchema.ts';

--- a/graphql-tools/utils/collectFields.ts
+++ b/graphql-tools/utils/collectFields.ts
@@ -7,7 +7,7 @@ import {
   isAbstractType,
 } from "../../deps.ts";
 
-import { GraphQLExecutionContext } from './Interfaces.ts';
+import type { GraphQLExecutionContext } from './Interfaces.ts';
 
 /**
  * Given a selectionSet, adds all of the fields in that selection to

--- a/graphql-tools/utils/fix-schema-ast.ts
+++ b/graphql-tools/utils/fix-schema-ast.ts
@@ -1,5 +1,5 @@
 import { buildSchema } from "../../deps.ts";
-import { SchemaPrintOptions } from './types.ts';
+import type { SchemaPrintOptions } from './types.ts';
 import { printSchemaWithDirectives } from './print-schema-with-directives.ts';
 
 function buildFixedSchema(schema: any, options: any & SchemaPrintOptions) {

--- a/graphql-tools/utils/forEachDefaultValue.ts
+++ b/graphql-tools/utils/forEachDefaultValue.ts
@@ -1,6 +1,6 @@
 import { getNamedType, isObjectType, isInputObjectType } from "../../deps.ts";
 
-import { IDefaultValueIteratorFn } from './Interfaces.ts';
+import type { IDefaultValueIteratorFn } from './Interfaces.ts';
 
 export function forEachDefaultValue(schema: any, fn: IDefaultValueIteratorFn): void {
   const typeMap = schema.getTypeMap();

--- a/graphql-tools/utils/forEachField.ts
+++ b/graphql-tools/utils/forEachField.ts
@@ -1,6 +1,6 @@
 import { getNamedType, isObjectType } from "../../deps.ts";
 
-import { IFieldIteratorFn } from './Interfaces.ts';
+import type { IFieldIteratorFn } from './Interfaces.ts';
 
 export function forEachField(schema: any, fn: IFieldIteratorFn): void {
   const typeMap = schema.getTypeMap();

--- a/graphql-tools/utils/getResolversFromSchema.ts
+++ b/graphql-tools/utils/getResolversFromSchema.ts
@@ -7,7 +7,7 @@ import {
   isSpecifiedScalarType,
 } from "../../deps.ts";
 
-import { IResolvers } from './Interfaces.ts';
+import type { IResolvers } from './Interfaces.ts';
 
 import { cloneType } from './clone.ts';
 

--- a/graphql-tools/utils/heal.ts
+++ b/graphql-tools/utils/heal.ts
@@ -11,7 +11,7 @@ import {
   isNonNullType,
 } from "../../deps.ts";
 
-import { TypeMap } from './Interfaces.ts';
+import type { TypeMap } from './Interfaces.ts';
 
 // Update any references to named schema types that disagree with the named
 // types found in schema.getTypeMap().

--- a/graphql-tools/utils/parse-graphql-json.ts
+++ b/graphql-tools/utils/parse-graphql-json.ts
@@ -1,8 +1,8 @@
 import { buildClientSchema, parse } from "../../deps.ts";
 // import { GraphQLSchemaValidationOptions } from 'graphql/type/schema';
 import { printSchemaWithDirectives } from './print-schema-with-directives.ts';
-import { Source } from './loaders.ts';
-import { SchemaPrintOptions } from './types.ts';
+import type { Source } from './loaders.ts';
+import type { SchemaPrintOptions } from './types.ts';
 
 function stripBOM(content: string): string {
   content = content.toString();

--- a/graphql-tools/utils/print-schema-with-directives.ts
+++ b/graphql-tools/utils/print-schema-with-directives.ts
@@ -7,7 +7,7 @@ import {
   isScalarType,
   parse,
 } from "../../deps.ts";
-import { SchemaPrintOptions } from './types.ts';
+import type { SchemaPrintOptions } from './types.ts';
 import { createSchemaDefinition } from './create-schema-definition.ts';
 
 export function printSchemaWithDirectives(schema: any, _options: SchemaPrintOptions = {}): string {

--- a/graphql-tools/utils/rewire.ts
+++ b/graphql-tools/utils/rewire.ts
@@ -21,7 +21,7 @@ import {
 } from "../../deps.ts";
 
 import { getBuiltInForStub, isNamedStub } from './stub.ts';
-import { TypeMap } from './Interfaces.ts';
+import type { TypeMap } from './Interfaces.ts';
 
 export function rewireTypes(
   originalTypeMap: Record<string, any | null>,

--- a/graphql-tools/utils/transforms.ts
+++ b/graphql-tools/utils/transforms.ts
@@ -1,6 +1,4 @@
-import { GraphQLSchema } from "../../deps.ts";
-
-import { Request, Transform } from './Interfaces.ts';
+import type { Request, Transform } from './Interfaces.ts';
 
 import { cloneSchema } from './clone.ts';
 

--- a/graphql-tools/utils/validate-documents.ts
+++ b/graphql-tools/utils/validate-documents.ts
@@ -3,7 +3,7 @@ import {
   validate,
   specifiedRules,
 } from "../../deps.ts";
-import { Source } from './loaders.ts';
+import type { Source } from './loaders.ts';
 import { CombinedError } from './errors.ts';
 
 export type ValidationRule = (context: any) => any;

--- a/graphql-tools/utils/visitSchema.ts
+++ b/graphql-tools/utils/visitSchema.ts
@@ -21,7 +21,7 @@ import {
 } from './Interfaces.ts';
 
 import { healSchema } from './heal.ts';
-import { SchemaVisitor } from './SchemaVisitor.ts';
+import type { SchemaVisitor } from './SchemaVisitor.ts';
 
 function isSchemaVisitor(obj: any): obj is SchemaVisitor {
   if ('schema' in obj && isSchema(obj.schema)) {

--- a/mod.ts
+++ b/mod.ts
@@ -3,4 +3,5 @@ import { GraphQLError, gql, PubSub } from "./deps.ts"
 
 export { gql, PubSub }
 export const GQLError = GraphQLError as any;
-export { applyGraphQL, ApplyGraphQLOptions, ResolversProps } from "./applyGraphQL.ts";
+export { applyGraphQL } from "./applyGraphQL.ts";
+export type { ApplyGraphQLOptions, ResolversProps } from "./applyGraphQL.ts";


### PR DESCRIPTION
This change does 2 things:
* Uses type-only imports where only types were being used  
  `import type {} from '...'`
* In files where types were only re-exported, re-exports those types using type-only exports  
  `export type { ... } from '...'`

For re-exports in cases where non-types were also being re-exported, a second export statement was added immediately below the non-type export so that exports from the same file are collocated.  See the changes in `graphql-subscriptions/index.ts` for an example.