### PR TITLE
Allow executable schema as property

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.ts]
+ij_typescript_align_multiline_parameters = false
+ij_typescript_blank_lines_around_method_in_interface = 0
+ij_typescript_spaces_within_array_initializer_brackets = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.DS_Store
+.idea
+
 /index.ts

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { default as gql } from "./graphql-tag/index.ts"
+export { default as gql } from "./graphql-tag/index.ts";
 
 // @ts-nocheck
 export {
@@ -141,4 +141,4 @@ export {
 // } from "https://raw.githubusercontent.com/graphql/graphql-js/deno/index.d.ts"
 
 export { PubSub } from "./graphql-subscriptions/index.ts";
-export { MultipartReader } from "https://deno.land/std@0.76.0/mime/multipart.ts";
+export { MultipartReader } from "https://deno.land/std@0.95.0/mime/multipart.ts";


### PR DESCRIPTION
This closes #9
Allows building the executable schema in a centralized file e. g. `schema.ts`
```
import type { IExecutableSchemaDefinition } from "deps.ts";
import { makeExecutableSchema } from "deps.ts";
import { bookTypeDefs, bookResolvers } from "book.ts";
import { authorTypeDefs, authorResolvers } from "author.ts";

const typeDefs: string = `
  type Query {
    _empty: String
  }
`;

export const graphQLSchema: IExecutableSchemaDefinition = makeExecutableSchema({
  typeDefs: [ typeDefs, bookTypeDefs, authorTypeDefs ],
  resolvers: [ bookResolvers, authorResolvers ]
});
```