### PR TITLE
Pin std package to non-deprecated version

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { default as gql } from "./graphql-tag/index.ts"
+export { default as gql } from "./graphql-tag/index.ts";
 
 // @ts-nocheck
 export {
@@ -141,4 +141,4 @@ export {
 // } from "https://raw.githubusercontent.com/graphql/graphql-js/deno/index.d.ts"
 
 export { PubSub } from "./graphql-subscriptions/index.ts";
-export { MultipartReader } from "https://deno.land/std/mime/multipart.ts";
+export { MultipartReader } from "https://deno.land/std@0.143.0/mime/multipart.ts";


### PR DESCRIPTION
I don't know what the maintenance status currently is of this package, but, the package recently stopped working for me because the `MultipartReader` was deprecated in `std@0.144.0`. 

I noticed there was an unpinned version import that was causing the breakage. This locks the import to the pre-deprecated version for better or for worse.

I don't currently have the bandwidth on my project to get into the details of the upload feature, so, this a temporary fix.